### PR TITLE
Update metalite_table1.R

### DIFF
--- a/R/metalite_table1.R
+++ b/R/metalite_table1.R
@@ -61,6 +61,19 @@ metalite_table1 <- function(formula,
 
   data[[group]] <- factor(data[[group]])
 
+  if (missing_group == "ignore") {
+    data <- data[!is.na(data[[group]]), ]
+    message("Ignore missing values in the group variable.")
+  } else if (missing_group == "count") {
+    data[[group]] <- addNA(data[[group]], ifany = TRUE)
+    levels(data[[group]]) <- c(levels(data[[group]]), "Missing")
+  } else if (missing_group == "display") {
+    data[[group]] <- addNA(data[[group]], ifany = TRUE)
+    levels(data[[group]]) <- c(levels(data[[group]]), "Missing")
+  } else {
+    stop("Invalid value for 'missing_group'.")
+  }
+
   var_label <- metalite::get_label(data)[var]
 
   plan <- metalite::plan(


### PR DESCRIPTION
Handling missing value when group contain missing values

The code is following:
install.packages("metalite.table1")
library(metalite.table1)
metalite_table1(~ AGE + SEX + RACE + BMIBLGR1 | ARM, data = r2rtf::r2rtf_adsl, id = "USUBJID")
library(dplyr)

handle_missing_group <- function(data, group, missing_group) {
  if (missing_group == "ignore") {
    data <- data[!is.na(data[[group]]), ]
    message("Ignore missing values in the group variable.")
  } else if (missing_group == "count") {
    data[[group]] <- addNA(data[[group]], ifany = TRUE)
    levels(data[[group]]) <- c(levels(data[[group]]), "Missing")
  } else if (missing_group == "display") {
    data[[group]] <- addNA(data[[group]], ifany = TRUE)
    levels(data[[group]]) <- c(levels(data[[group]]), "Missing")
  } else {
    stop("Invalid value for 'missing_group'.")
  }
  
  return(data)
}
data <- r2rtf::r2rtf_adsl

updated_data <- data %>%
  mutate(
    AGE = if_else(runif(n()) < 0.1, NA, AGE),  
    SEX = if_else(runif(n()) < 0.04, NA, SEX), 
    RACE = if_else(runif(n()) < 0.07, NA, RACE), 
    BMIBLGR1 = if_else(runif(n()) < 0.02, NA, BMIBLGR1) 
  )
updated_data <- handle_missing_group(updated_data, "AGE", "count")

metalite_table1(~ AGE + SEX + RACE + BMIBLGR1 | ARM, data = updated_data, id = "USUBJID")

we can change the "updated_data <- handle_missing_group(updated_data, "AGE", "count")" to "updated_data <- handle_missing_group(updated_data, "AGE", "display")" or "updated_data <- handle_missing_group(updated_data, "AGE", "ignore")".

when we fill "updated_data <- handle_missing_group(updated_data, "AGE":
<img width="470" alt="截屏2024-06-05 下午12 47 45" src="https://github.com/elong0527/metalite.table1/assets/170619189/b7ab5c67-22bc-4494-8b26-414cbe3bc837">
